### PR TITLE
Replace node-fetch with undici (closes #2)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,8 +11,6 @@ jobs:
     steps:
       - name: Use Node.js ⚙️
         uses: actions/setup-node@v3
-        with:
-          node-version: '16'
 
       - name: Checkout 🛎️
         uses: actions/checkout@v3
@@ -47,7 +45,7 @@ jobs:
       - name: Use Node.js ⚙️
         uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: '18'
 
       - name: Test 🧪
         run: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,8 +9,6 @@ jobs:
     steps:
       - name: Use Node.js ⚙️
         uses: actions/setup-node@v3
-        with:
-          node-version: '16'
 
       - name: Checkout 🛎️
         uses: actions/checkout@v3
@@ -45,7 +43,7 @@ jobs:
       - name: Use Node.js ⚙️
         uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: '18'
 
       - name: Test 🧪
         run: |

--- a/lib/fetch-text.js
+++ b/lib/fetch-text.js
@@ -1,4 +1,4 @@
-const fetch = require('node-fetch')
+const {fetch} = require('undici')
 
 /**
  * @param {string} url

--- a/lib/fetch-text.js
+++ b/lib/fetch-text.js
@@ -1,4 +1,4 @@
-const {fetch} = require('undici')
+const { fetch } = require('undici')
 
 /**
  * @param {string} url

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "homepage": "https://github.com/awesome-webextension/webextension-store-meta#readme",
   "engines": {
-    "node": ">=10.3.0"
+    "node": "^18"
   },
   "devDependencies": {
     "cheerio": "1.0.0-rc.12",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,6 @@
   "dependencies": {
     "domhandler": "^4.0.0",
     "htmlparser2": "^6.1.0",
-    "node-fetch": "^2.6.1"
+    "undici": "^6.11.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,9 @@ dependencies:
   htmlparser2:
     specifier: ^6.1.0
     version: 6.1.0
-  node-fetch:
-    specifier: ^2.6.1
-    version: 2.6.11
+  undici:
+    specifier: ^6.11.1
+    version: 6.11.1
 
 devDependencies:
   cheerio:
@@ -36,7 +36,7 @@ devDependencies:
     version: 5.0.0(eslint@8.47.0)(prettier@3.0.3)
   fetch-mock-jest:
     specifier: ^1.5.1
-    version: 1.5.1(node-fetch@2.6.11)
+    version: 1.5.1
   fs-extra:
     specifier: ^11.1.1
     version: 11.1.1
@@ -1676,7 +1676,7 @@ packages:
       bser: 2.1.1
     dev: true
 
-  /fetch-mock-jest@1.5.1(node-fetch@2.6.11):
+  /fetch-mock-jest@1.5.1:
     resolution: {integrity: sha512-+utwzP8C+Pax1GSka3nFXILWMY3Er2L+s090FOgqVNrNCPp0fDqgXnAHAJf12PLHi0z4PhcTaZNTz8e7K3fjqQ==}
     engines: {node: '>=8.0.0'}
     peerDependencies:
@@ -1685,13 +1685,12 @@ packages:
       node-fetch:
         optional: true
     dependencies:
-      fetch-mock: 9.11.0(node-fetch@2.6.11)
-      node-fetch: 2.6.11
+      fetch-mock: 9.11.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /fetch-mock@9.11.0(node-fetch@2.6.11):
+  /fetch-mock@9.11.0:
     resolution: {integrity: sha512-PG1XUv+x7iag5p/iNHD4/jdpxL9FtVSqRMUQhPab4hVDt80T1MH5ehzVrL2IdXO9Q2iBggArFvPqjUbHFuI58Q==}
     engines: {node: '>=4.0.0'}
     peerDependencies:
@@ -1707,7 +1706,6 @@ packages:
       glob-to-regexp: 0.4.1
       is-subset: 0.1.1
       lodash.isequal: 4.5.0
-      node-fetch: 2.6.11
       path-to-regexp: 2.4.0
       querystring: 0.2.1
       whatwg-url: 6.5.0
@@ -2754,17 +2752,6 @@ packages:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
     dev: true
 
-  /node-fetch@2.6.11:
-    resolution: {integrity: sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==}
-    engines: {node: 4.x || >=6.0.0}
-    peerDependencies:
-      encoding: ^0.1.0
-    peerDependenciesMeta:
-      encoding:
-        optional: true
-    dependencies:
-      whatwg-url: 5.0.0
-
   /node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
     dev: true
@@ -3324,9 +3311,6 @@ packages:
       punycode: 2.3.0
     dev: true
 
-  /tr46@0.0.3:
-    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
-
   /tr46@1.0.1:
     resolution: {integrity: sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==}
     dependencies:
@@ -3368,6 +3352,11 @@ packages:
     resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
     engines: {node: '>=10'}
     dev: true
+
+  /undici@6.11.1:
+    resolution: {integrity: sha512-KyhzaLJnV1qa3BSHdj4AZ2ndqI0QWPxYzaIOio0WzcEJB9gvuysprJSLtpvc2D9mhR9jPDUk7xlJlZbH2KR5iw==}
+    engines: {node: '>=18.0'}
+    dev: false
 
   /universalify@2.0.0:
     resolution: {integrity: sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==}
@@ -3426,18 +3415,9 @@ packages:
       makeerror: 1.0.12
     dev: true
 
-  /webidl-conversions@3.0.1:
-    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
-
   /webidl-conversions@4.0.2:
     resolution: {integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==}
     dev: true
-
-  /whatwg-url@5.0.0:
-    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
-    dependencies:
-      tr46: 0.0.3
-      webidl-conversions: 3.0.1
 
   /whatwg-url@6.5.0:
     resolution: {integrity: sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==}


### PR DESCRIPTION
`undici` seems to support redirecting with a non-ASCII `Location` response header from Chrome Web Store