### PR TITLE
Loosen `engines.node` constraint

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,11 +8,14 @@ on:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: ['18', '20']
     steps:
       - name: Use Node.js ⚙️
         uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: ${{ matrix.node }}
 
       - name: Checkout 🛎️
         uses: actions/checkout@v3

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,11 +6,14 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: ['18', '20']
     steps:
       - name: Use Node.js ⚙️
         uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: ${{ matrix.node }}
 
       - name: Checkout 🛎️
         uses: actions/checkout@v3

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "homepage": "https://github.com/awesome-webextension/webextension-store-meta#readme",
   "engines": {
-    "node": "^18"
+    "node": ">=18"
   },
   "devDependencies": {
     "@biomejs/biome": "1.6.1",


### PR DESCRIPTION
77c348c6 sets `engines.node` to `^18`.

For packages, the `engines` constraints should be wide. It does not seem like there is any strong reason why this library is not compatible with node >=19. The test suite passes on node 20.

In this PR, I have opened the constraint and set the CI builds to run against in-range LTS node versions.