### PR TITLE
Fix parse version from manifest (parseVersionFromManifest)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,6 @@ dist
 lib/
 
 docs/
+
+# Jetbrains
+/.idea

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
   "dependencies": {
     "domhandler": "^4.0.0",
     "htmlparser2": "^6.1.0",
+    "json5": "^2.2.3",
     "undici": "^6.11.1"
   },
   "packageManager": "pnpm@9.12.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       htmlparser2:
         specifier: ^6.1.0
         version: 6.1.0
+      json5:
+        specifier: ^2.2.3
+        version: 2.2.3
       undici:
         specifier: ^6.11.1
         version: 6.11.1
@@ -574,6 +577,11 @@ packages:
 
   js-tokens@9.0.0:
     resolution: {integrity: sha512-WriZw1luRMlmV3LGJaR6QOJjWwgLUTf89OwT2lUOyjX2dJGBwgmIkbcz+7WFZjrZM635JOIR517++e/67CP9dQ==}
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
 
   jsonc-parser@3.2.0:
     resolution: {integrity: sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==}
@@ -1372,6 +1380,8 @@ snapshots:
       istanbul-lib-report: 3.0.1
 
   js-tokens@9.0.0: {}
+
+  json5@2.2.3: {}
 
   jsonc-parser@3.2.0: {}
 

--- a/src/chrome-web-store/__tests__/chrome-web-store.test.ts
+++ b/src/chrome-web-store/__tests__/chrome-web-store.test.ts
@@ -103,9 +103,27 @@ describe("Chrome Web Store", async () => {
         );
       });
 
-      it("should throw error if document is not loaded", () => {
+      it("should throw error if document is not loaded", async () => {
+        try {
+          const chromeWebStore = new ChromeWebStore({ id });
+          await chromeWebStore.load();
+          const version = chromeWebStore.version();
+
+          process.env.allowVersionFallback = "true";
+          // @ts-ignore
+          const versionFallback = chromeWebStore.versionFallback();
+          expect(versionFallback).toBe(version);
+        } finally {
+            delete process.env.allowVersionFallback;
+        }
+
+
+      });
+
+      it("should available versionFallback ", async () => {
         const chromeWebStore = new ChromeWebStore({ id });
-        expect(() => chromeWebStore.meta()).toThrow();
+        await chromeWebStore.load();
+        expect(chromeWebStore.meta()).toMatchObject(matchAnyInfo);
       });
     },
     20000,

--- a/src/chrome-web-store/__tests__/chrome-web-store.test.ts
+++ b/src/chrome-web-store/__tests__/chrome-web-store.test.ts
@@ -60,7 +60,7 @@ describe("Chrome Web Store", async () => {
         lastUpdated: null,
       });
     } finally {
-        delete process.env.allowVersionFallback;
+      process.env.allowVersionFallback = undefined;
     }
   });
 
@@ -114,7 +114,7 @@ describe("Chrome Web Store", async () => {
           const versionFallback = chromeWebStore.versionFallback();
           expect(versionFallback).toBe(version);
         } finally {
-            delete process.env.allowVersionFallback;
+          process.env.allowVersionFallback = undefined;
         }
 
 

--- a/src/chrome-web-store/index.ts
+++ b/src/chrome-web-store/index.ts
@@ -191,7 +191,7 @@ export class ChromeWebStore {
   private versionFallback(): string | null {
     // Warn in vitest if execution reaches here
     if (process.env.VITEST && process.env.VITEST === "true" && !process.env.allowVersionFallback) {
-      throw new Error("fallback method is being used, please check if versionClassName is correct. (" + this.versionClassName + ")");
+      throw new Error(`fallback method is being used, please check if versionClassName is correct. (${this.versionClassName})`);
     }
     const AF_initDataCallbackEl = queryOne(this.dom, "ds:0");
     const rawText = getText(AF_initDataCallbackEl);


### PR DESCRIPTION
Hi @crimx ,

I found that `parseVersionFromManifest` is no longer valid.

Below is an explanation of the fallback method for extracting the extension version from a Chrome Web Store detail page.

This function searches for a <script class="ds:0"> element, which contains a JS literal of the form
`AF_initDataCallback({ ... });`. The literal is parsed as a string, and the inner object is extracted.
For example:
`<script class="ds:0" nonce>AF_initDataCallback(...);</script>`
The manifest JSON string is located at the last element of data[0] in the parsed object.
The function parses this manifest string and returns the version field.

Example:
```
{
  key: 'ds:0',
  hash: '2',
  data: [
    [
      ...,
      "{\n \"version": \"7.20.0\n ...\n}",
    ],
    ...,
  ],
  sideChannel: {}
}
```